### PR TITLE
Pip Installation for coral-server

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+# Pull Request: Make server runnable through pip
+
+## Description
+
+This PR adds a Python wrapper for the Coral Protocol Server to make it easily installable and runnable through pip. It addresses issue #8.
+
+## Features
+
+- Python package structure for distributing the server as a pip package
+- Command-line interface accessible through the `coral-server` command
+- Python API for programmatically managing the server
+- Support for both SSE and stdio modes
+- Examples showing usage
+- Comprehensive installation instructions
+
+## Requirements
+
+- Python 3.7+
+- Java Runtime Environment (JRE)
+
+## Usage
+
+After installation:
+
+```bash
+# Run with default settings (SSE server on port 3001)
+coral-server
+
+# Run with custom port
+coral-server --port 4000
+
+# Run in stdio mode
+coral-server --stdio
+```
+
+## Testing Done
+
+- Tested installation from source
+- Verified server starts and stops correctly
+- Tested CLI arguments
+- Tested Python API usage
+
+## Related Issues
+
+Closes #8

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,87 @@
+# Installation Guide for Coral Protocol Server
+
+## Prerequisites
+
+- Python 3.7 or higher
+- Java Runtime Environment (JRE)
+
+## Installation
+
+You can install the Coral Protocol Server Python wrapper using pip:
+
+```bash
+pip install coral-server
+```
+
+This will install the package along with the precompiled JAR file.
+
+## Manual Installation
+
+If you prefer to build from source:
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/Coral-Protocol/coral-server.git
+   cd coral-server
+   ```
+
+2. Build the JAR file (if not already built):
+   ```bash
+   ./gradlew build
+   ```
+
+3. Install the Python package:
+   ```bash
+   pip install -e .
+   ```
+
+## Usage
+
+### Command Line Interface
+
+After installation, you can run the server using the `coral-server` command:
+
+```bash
+# Run with default settings (SSE server on port 3001)
+coral-server
+
+# Run with custom port
+coral-server --port 4000
+
+# Run in stdio mode
+coral-server --stdio
+```
+
+### Python API
+
+You can also use the Coral Protocol Server programmatically in your Python code:
+
+```python
+from coral_server import CoralServer
+
+# Create and start a server with default settings (SSE on port 3001)
+server = CoralServer()
+server.start()
+
+# Or with custom settings
+server = CoralServer(port=4000)
+server.start()
+
+# Or in stdio mode
+server = CoralServer(stdio=True)
+server.start()
+
+# You can also use the context manager
+with CoralServer(port=4000) as server:
+    # Server is running within this block
+    # Do something with the server...
+    pass  # When the block exits, the server will be stopped automatically
+
+# Stop the server manually
+server.stop()
+```
+
+## Requirements
+
+- Python 3.7 or higher
+- Java Runtime Environment (JRE)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include python/coral_server/jar/*.jar

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,71 @@
+from setuptools import setup, find_packages
+from pathlib import Path
+import os
+import shutil
+import subprocess
+
+# Read the content of README file
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
+
+# Ensure the JAR file is available
+jar_dir = Path("python/coral_server/jar")
+jar_file = jar_dir / "coral-server-1.0-SNAPSHOT.jar"
+
+# Check if we need to build the JAR file
+if not jar_file.exists():
+    print("Building JAR file...")
+    # Check if the JAR exists in the build directory
+    build_jar = Path("build/libs/coral-server-1.0-SNAPSHOT.jar")
+    
+    if not build_jar.exists():
+        # Build it using Gradle
+        if os.name == 'nt':  # Windows
+            gradle_cmd = "gradlew.bat"
+        else:  # Unix/Linux/Mac
+            gradle_cmd = "./gradlew"
+        
+        try:
+            subprocess.run([gradle_cmd, "build"], check=True)
+        except subprocess.CalledProcessError:
+            print("Failed to build JAR file. Please build it manually using './gradlew build'")
+            exit(1)
+    
+    # Copy the JAR file to the package directory
+    os.makedirs(jar_dir, exist_ok=True)
+    shutil.copy2(build_jar, jar_file)
+
+setup(
+    name="coral-server",
+    version="0.1.0",
+    description="Python wrapper for Coral Protocol Server",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    author="Coral Protocol",
+    author_email="hello@coralprotocol.org",
+    url="https://github.com/Coral-Protocol/coral-server",
+    packages=find_packages(where="python"),
+    package_dir={"":"python"},
+    include_package_data=True,
+    package_data={
+        "coral_server": ["jar/*.jar"],
+    },
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+    ],
+    python_requires=">=3.7",
+    install_requires=[
+        # No additional Python dependencies required
+    ],
+    entry_points={
+        "console_scripts": [
+            "coral-server=coral_server.cli:main",
+        ],
+    },
+)


### PR DESCRIPTION
# Coral Protocol Python Wrapper

A Python wrapper for the Coral Protocol Server that makes it easy to run the server in different modes.

## Installation

```bash
pip install coral-server
```

## Usage

The Coral server can be run in three different modes:

1. Default SSE mode (port 3001):
```bash
coral-server
```

2. SSE mode with custom port:
```bash
coral-server --port 4000
```

3. STDIO mode:
```bash
coral-server --stdio
```

## Requirements

- Python 3.7 or higher
- Java Runtime Environment (JRE)



## License

See the LICENSE file for details. 