### PR TITLE
feat: custom MCP tool injection

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,8 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json")
     implementation("io.ktor:ktor-client-plugins")
 
+    implementation("net.pwall.json:json-kotlin-schema:0.56")
+
     // Ktor server dependencies
     implementation("io.ktor:ktor-server-core")
     implementation("io.ktor:ktor-server-cio")

--- a/src/main/kotlin/org/coralprotocol/coralserver/mcptools/WaitForMentionsTool.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/mcptools/WaitForMentionsTool.kt
@@ -63,7 +63,7 @@ private suspend fun CoralAgentIndividualMcp.handleWaitForMentions(request: CallT
 
         if (messages.isNotEmpty()) {
             logger.info { "Received ${messages.size} messages for agent $connectedAgentId" }
-            val formattedMessages = XML.encodeToString (messages.map { message -> message.resolve() })
+            val formattedMessages = XML.encodeToString (messages .map { message -> message.resolve() })
             return CallToolResult(
                 content = listOf(TextContent(formattedMessages))
             )

--- a/src/main/kotlin/org/coralprotocol/coralserver/models/Agent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/models/Agent.kt
@@ -1,6 +1,8 @@
 package org.coralprotocol.coralserver.models
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+import org.coralprotocol.coralserver.session.CustomTool
 
 /**
  * Represents an agent in the system.
@@ -9,5 +11,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 class Agent(
     val id: String,
-    val description: String = "" // Description of the agent's responsibilities
+    val description: String = "", // Description of the agent's responsibilities
+    @Transient
+    val extraTools: Set<CustomTool> = setOf()
 )

--- a/src/main/kotlin/org/coralprotocol/coralserver/routes/SessionRoutes.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/routes/SessionRoutes.kt
@@ -50,6 +50,8 @@ fun Routing.sessionRoutes(sessionManager: SessionManager, devMode: Boolean) {
                 }
 
                 AgentGraph(
+                    tools = it.tools,
+                    links = it.links,
                     agents = agents.mapValues { agent ->
                         when (val agentReq = agent.value) {
                             is GraphAgentRequest.Local -> {
@@ -80,15 +82,14 @@ fun Routing.sessionRoutes(sessionManager: SessionManager, devMode: Boolean) {
                                 GraphAgent.Local(
                                     blocking = agentReq.blocking ?: true,
                                     agentType = agentReq.agentType,
+                                    extraTools = agentReq.tools,
                                     options = defaultOptions + setOptions
                                 )
                             }
 
                             else -> TODO("(alan) remote agent option resolution")
                         }
-
-                    },
-                    links = it.links
+                    }
                 )
             }
 
@@ -103,6 +104,7 @@ fun Routing.sessionRoutes(sessionManager: SessionManager, devMode: Boolean) {
                         agentGraph
                     )
                 }
+
                 false -> {
                     sessionManager.createSession(request.applicationId, request.privacyKey, agentGraph)
                 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/routes/SseRoutes.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/routes/SseRoutes.kt
@@ -96,13 +96,13 @@ private suspend fun handleSseConnection(
     }
     val currentCount = session.getRegisteredAgentsCount()
     logger.info { "DevMode: Current agent count for session ${session.id} (object id: ${session}) (from sessionmanager: ${sessionManager}): $currentCount, waiting for: ${session.devRequiredAgentStartCount}" }
-    // Create the agent object
-    val agent = Agent(
-        id = agentId,
-        description = agentDescription
-    )
     // Register the agent
-    session.registerAgent(agent)
+    val agent = session.registerAgent(agentId, agentDescription)
+    if (agent == null) {
+        sseProducer.call.respond(HttpStatusCode.BadRequest, "Agent ID already exists")
+        return false
+    }
+
     val newCount = session.getRegisteredAgentsCount()
     logger.info { "DevMode: New agent count for session ${session.id} (object id: ${session})after registering: $newCount" }
 

--- a/src/main/kotlin/org/coralprotocol/coralserver/routes/SseRoutes.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/routes/SseRoutes.kt
@@ -110,7 +110,7 @@ private suspend fun handleSseConnection(
     val transport = SseServerTransport("$routePrefix/$applicationId/$privacyKey/$sessionId/message", sseProducer)
 
     val individualServer =
-        CoralAgentIndividualMcp(transport, session, agentId, maxWaitForMentionsTimeout)
+        CoralAgentIndividualMcp(transport, session, agentId, maxWaitForMentionsTimeout, extraTools = agent.extraTools)
     session.coralAgentConnections.add(individualServer)
 
     val transportSessionId = transport.sessionId

--- a/src/main/kotlin/org/coralprotocol/coralserver/server/CoralAgentIndividualMcp.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/server/CoralAgentIndividualMcp.kt
@@ -7,6 +7,8 @@ import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.SseServerTransport
 import org.coralprotocol.coralserver.session.CoralAgentGraphSession
 import org.coralprotocol.coralserver.mcptools.addThreadTools
+import org.coralprotocol.coralserver.session.CustomTool
+import org.coralprotocol.coralserver.session.addExtraTool
 
 /**
  * Represents a persistent connection to a Coral agent.
@@ -30,6 +32,7 @@ class CoralAgentIndividualMcp(
      */
     val connectedAgentId: String,
     val maxWaitForMentionsTimeoutMs: Long = 2000,
+    val extraTools: Set<CustomTool> = setOf(),
 ) : Server(
     Implementation(
         name = "Coral Server",
@@ -45,6 +48,9 @@ class CoralAgentIndividualMcp(
 ) {
     init {
         addThreadTools()
+        extraTools.forEach {
+            addExtraTool(it)
+        }
     }
 
     suspend fun closeTransport() {

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/AgentGraph.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/AgentGraph.kt
@@ -14,21 +14,25 @@ value class AgentName(private val name: String) {
 @Serializable
 data class AgentGraph(
     val agents: Map<AgentName, GraphAgent>,
+    val tools: Map<String, CustomTool>,
     val links: Set<Set<String>>,
 )
 
 sealed interface GraphAgent {
     val options: Map<String, ConfigValue>
+    val extraTools: Set<String>
     val blocking: Boolean
 
     data class Remote(
         val remote: AgentRuntime.Remote,
+        override val extraTools: Set<String> = setOf(),
         override val options: Map<String, ConfigValue> = mapOf(),
         override val blocking: Boolean = true
     ) : GraphAgent
 
     data class Local(
         val agentType: AgentType,
+        override val extraTools: Set<String> = setOf(),
         override val options: Map<String, ConfigValue> = mapOf(),
         override val blocking: Boolean = true
     ) :

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/CoralAgentGraphSession.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/CoralAgentGraphSession.kt
@@ -19,6 +19,7 @@ class CoralAgentGraphSession(
     val id: String,
     val applicationId: String,
     val privacyKey: String,
+    val agentGraph: AgentGraph?,
     val coralAgentConnections: MutableList<CoralAgentIndividualMcp> = mutableListOf(),
     val groups: List<Set<String>> = listOf(),
     var devRequiredAgentStartCount: Int = 0,
@@ -52,16 +53,23 @@ class CoralAgentGraphSession(
         agentGroupScheduler.clear()
     }
 
-    suspend fun registerAgent(agent: Agent): Boolean {
-        if (agents.containsKey(agent.id)) {
-            return false
+    suspend fun registerAgent(agentId: String, agentDescription: String?): Agent? {
+        if (agents.containsKey(agentId)) {
+            return null
         }
+        val agent = Agent(
+            id = agentId,
+            description = agentDescription ?: "",
+            extraTools = agentGraph?.let {
+                it.agents[AgentName(agentId)]?.extraTools?.mapNotNull { tool -> it.tools[tool] }?.toSet()
+            } ?: setOf()
+        )
         agents[agent.id] = agent
 
         agentGroupScheduler.registerAgent(agent.id)
         countBasedScheduler.registerAgent(agent.id)
         eventBus.emit(Event.AgentRegistered(agent))
-        return true
+        return agent
     }
 
     fun getRegisteredAgentsCount(): Int = countBasedScheduler.getRegisteredAgentsCount()

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionManager.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionManager.kt
@@ -107,7 +107,7 @@ class SessionManager(val orchestrator: Orchestrator = Orchestrator(), val port: 
             }
             subgraphs
         }
-        val session = CoralAgentGraphSession(sessionId, applicationId, privacyKey)
+        val session = CoralAgentGraphSession(sessionId, applicationId, privacyKey, agentGraph = agentGraph, groups = subgraphs?.toList() ?: emptyList())
         sessions[sessionId] = session
         sessionListeners[sessionId]?.let { it ->
             it.forEach {

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionManager.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionManager.kt
@@ -99,11 +99,11 @@ class SessionManager(val orchestrator: Orchestrator = Orchestrator(), val port: 
             }
 
             it.agents.forEach { agent ->
-                orchestrator.spawn(
-                    agent.value,
-                    agentName = agent.key.toString(),
-                    connectionUrl = "http://localhost:${port}/${applicationId}/${privacyKey}/${sessionId}/sse?agentId=${agent.key}"
-                )
+//                orchestrator.spawn(
+//                    agent.value,
+//                    agentName = agent.key.toString(),
+//                    connectionUrl = "http://localhost:${port}/${applicationId}/${privacyKey}/${sessionId}/sse?agentId=${agent.key}"
+//                )
             }
             subgraphs
         }

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionModels.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionModels.kt
@@ -1,10 +1,25 @@
 package org.coralprotocol.coralserver.session
 
+import com.chrynan.uri.core.Uri
+import com.chrynan.uri.core.UriString
+import io.ktor.http.*
+import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.*
+import net.pwall.json.schema.JSONSchema
 import org.coralprotocol.coralserver.orchestrator.AgentType
 import org.coralprotocol.coralserver.orchestrator.runtime.AgentRuntime
+import org.coralprotocol.coralserver.server.CoralAgentIndividualMcp
 
 /**
  * Data class for session creation request.
@@ -21,21 +36,77 @@ data class CreateSessionRequest(
 data class AgentGraphRequest(
     val agents: HashMap<AgentName, GraphAgentRequest>,
     val links: Set<Set<String>>,
+    val tools: HashMap<String, CustomTool>,
 )
+
+object JSONSchemaSerializer : KSerializer<JSONSchemaWithRaw> {
+    // Serial names of descriptors should be unique, so choose app-specific name in case some library also would declare a serializer for Date.
+    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("org.coralprotocol.JSONSchemaWithRaw") {
+        
+    }
+    override fun serialize(encoder: Encoder, value: JSONSchemaWithRaw) {
+        val json = encoder as? JsonEncoder ?: throw SerializationException("Can be serialized only as JSON")
+        return json.encodeJsonElement(value.raw)
+    }
+    override fun deserialize(decoder: Decoder): JSONSchemaWithRaw {
+        val jsonInput = decoder as? JsonDecoder ?: error("Can be deserialized only by JSON")
+        val obj = jsonInput.decodeJsonElement().jsonObject;
+
+        return JSONSchemaWithRaw(schema = JSONSchema.parse(obj.toString()), raw = obj)
+    }
+}
+
+@Serializable(with = JSONSchemaSerializer::class)
+data class JSONSchemaWithRaw(
+    val schema: JSONSchema,
+    val raw: JsonObject,
+)
+
+@Serializable
+data class CustomTool(
+    val transport: ToolTransport,
+    val toolSchema: Tool,
+)
+
+fun CoralAgentIndividualMcp.addExtraTool(tool: CustomTool) {
+    addTool(
+        name = tool.toolSchema.name,
+        description = tool.toolSchema.description ?: "",
+        inputSchema = tool.toolSchema.inputSchema,
+    ) {
+        request -> tool.transport.handleRequest(request)
+    }
+}
+
+@Serializable
+sealed interface ToolTransport {
+    @SerialName("http")
+    @Serializable
+    data class Http(val url: UriString): ToolTransport {
+        override suspend fun handleRequest(request: CallToolRequest): CallToolResult {
+            return CallToolResult(
+                content = listOf(TextContent("the weather is a sunny 18 degrees, with light showers throughout"))
+            )
+        }
+    }
+
+    suspend fun handleRequest(request: CallToolRequest): CallToolResult
+}
 
 @Serializable
 sealed interface GraphAgentRequest {
     val options: Map<String, JsonPrimitive>
     val blocking: Boolean?
+    val tools: Set<String>
 
     @Serializable
     @SerialName("remote")
-    data class Remote(val remote: AgentRuntime.Remote, override val options: Map<String, JsonPrimitive> = mapOf(), override val blocking: Boolean? = true) :
+    data class Remote(val remote: AgentRuntime.Remote, override val options: Map<String, JsonPrimitive> = mapOf(), override val tools: Set<String> = setOf(), override val blocking: Boolean? = true) :
         GraphAgentRequest
 
     @Serializable
     @SerialName("local")
-    data class Local(val agentType: AgentType, override val options: Map<String, JsonPrimitive> = mapOf(), override val blocking: Boolean? = true) :
+    data class Local(val agentType: AgentType, override val options: Map<String, JsonPrimitive> = mapOf(), override val tools: Set<String> = setOf(), override val blocking: Boolean? = true) :
         GraphAgentRequest
 }
 

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionModels.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionModels.kt
@@ -110,6 +110,7 @@ sealed interface ToolTransport {
                 val req = HttpRequest.newBuilder()
                     .POST(HttpRequest.BodyPublishers.ofString(Json.encodeToString(request.arguments)))
                     .uri(appendUri(url.value, "agentName=$agentId"))
+                    .header("Content-Type", "application/json")
                     .build();
 
                 // TODO: better thread context


### PR DESCRIPTION
- adds a `tools` field to the `agentGraph` in the create session POST request.
- adds an optional `tools` field to each agent, that lets you define which of the custom tools this agent can access

## Example
Here we define a tool called get_weather_tool internally, and `get_weather` externally (agent's only see the `name` field inside `toolSchema`)
- The `my-interface` agent is given this tool, by putting the tool id (`get_weather_tool`) in the `tools` array of that agent.
- Whenever the tool is called, the relevant transport is invoked to "pass" the call on to wherever the application developer wants
  - Currently only the 'http' transport is available, which just does a POST to the given url, with the query parameter `agentId`, and the JSON body the agent called the tool with.
```jsonc
{
  // ...
  "agentGraph": {
    "tools": {
      "get_weather_tool": {
        "transport": {
          "type": "http",
          // some endpoint the application developer has control over/knows about
          "url": "http://127.0.0.1:1111/my-tools/weather-tool/"
        },
        "toolSchema": {
          "name": "get_weather",
          "description": "Get current weather information for a location",
          "inputSchema": {
            "type": "object",
            "properties": {
              "location": {
                "type": "string",
                "description": "City name or zip code"
              }
            },
            "required": [
              "location"
            ]
          }
        }
      }
    },
    "agents": {
      "my-interface": {
        "type": "local",
        "agentType": "interface",
        "tools": [
          "get_weather_tool"
        ],
        // ...
      }
    },
    "links": []
  }
}
```