### PR TITLE
Docker orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ bin/
 
 ### Example directories ###
 examples/camel-search-maths/__pycache__/
+examples/session-posts/**.env.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,6 @@ repositories {
     }
 
     maven("https://repo.repsy.io/mvn/chrynan/public")
-
 }
 
 
@@ -36,6 +35,7 @@ dependencies {
     implementation("io.github.pdvrieze.xmlutil:serialization:0.91.0")
     implementation("io.github.pdvrieze.xmlutil:core-jdk:0.91.0")
     implementation("io.github.pdvrieze.xmlutil:serialization-jvm:0.91.0")
+    implementation("com.github.docker-java:docker-java:3.5.1")
 
 
     // Hoplite for configuration

--- a/examples/session-posts/Local docker session.http
+++ b/examples/session-posts/Local docker session.http
@@ -6,32 +6,33 @@ Content-Type: application/json
   "privacyKey": "priv",
   "agentGraph": {
     "agents": {
-      "my-search": {
+      "my-deepresearch": {
         "type": "local",
-        "agentType": "search",
+        "agentType": "deepresearch",
         "options": {
           "OPENAI_API_KEY": "{{OPENAI_API_KEY}}",
-          "GOOGLE_API_KEY": "{{GOOGLE_API_KEY}}",
-          "SEARCH_ENGINE_ID": "{{SEARCH_ENGINE_ID}}"
+          "LINKUP_API_KEY": "{{LINKUP_API_KEY}}"
         }
       },
-      "my-math": {
+      "my-repounderstanding": {
         "type": "local",
-        "agentType": "math",
+        "agentType": "repounderstanding",
         "options": {
-          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}"
+          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}",
+          "GITHUB_ACCESS_TOKEN": "{{GITHUB_ACCESS_TOKEN}}"
         }
       },
       "my-interface": {
         "type": "local",
         "agentType": "interface",
         "options": {
-          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}"
+          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}",
+          "HUMAN_RESPONSE": "Please give me a comprehensive instruction of the master branch of Coral-Protocol/coral-server."
         }
       }
     },
     "links": [
-      ["my-math", "my-search", "my-interface"]
+      ["my-repounderstanding", "my-deepresearch", "my-interface"]
     ]
   }
 }

--- a/examples/session-posts/Local docker session.http
+++ b/examples/session-posts/Local docker session.http
@@ -1,0 +1,40 @@
+POST http://localhost:5555/sessions
+Content-Type: application/json
+
+{
+  "applicationId": "app",
+  "privacyKey": "priv",
+  "agentGraph": {
+    "agents": {
+      "my-search": {
+        "type": "local",
+        "agentType": "search",
+        "options": {
+          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}",
+          "GOOGLE_API_KEY": "{{GOOGLE_API_KEY}}",
+          "SEARCH_ENGINE_ID": "{{SEARCH_ENGINE_ID}}"
+        }
+      },
+      "my-math": {
+        "type": "local",
+        "agentType": "math",
+        "options": {
+          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}"
+        }
+      },
+      "my-interface": {
+        "type": "local",
+        "agentType": "interface",
+        "options": {
+          "OPENAI_API_KEY": "{{OPENAI_API_KEY}}"
+        }
+      }
+    },
+    "links": [
+      ["my-math", "my-search", "my-interface"]
+    ]
+  }
+}
+
+
+###

--- a/examples/session-posts/application.yaml
+++ b/examples/session-posts/application.yaml
@@ -13,63 +13,69 @@ applications:
 
 # Registry of agents we can orchestrate
 registry:
-  test:
-    options:
-      - name: "NAME"
-        type: "string"
-        description: "Test agent name"
-    runtime:
-      type: "executable"
-      command: ["bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/test.py"]
-      environment:
-        - option: "NAME"
-  search:
+  #  test:
+  #    options:
+  #      - name: "NAME"
+  #        type: "string"
+  #        description: "Test agent name"
+  #    runtime:
+  #      type: "executable"
+  #      command: ["bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/test.py"]
+  #      environment:
+  #        - option: "NAME"
+  repounderstanding:
     # Exposed configuration for consumers of this agent
     options:
       - name: "OPENAI_API_KEY"
         type: "string"
         description: "OpenAI API Key"
-      - name: "GOOGLE_API_KEY"
+      - name: "GITHUB_ACCESS_TOKEN"
         type: "string"
-        description: "Google API Key"
-      - name: "SEARCH_ENGINE_ID"
-        type: "string"
-        description: "Google Search Engine ID"
+        description: "GitHub Access Token"
 
     # How this agent is actually orchestrated locally
     runtime:
-      type: "executable"
-      command: [ "bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/mcp_example_camel_search.py" ]
-
+      type: "docker"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"
-        - option: "GOOGLE_API_KEY"
-        - option: "SEARCH_ENGINE_ID"
-  math:
+        - name: "GITHUB_ACCESS_TOKEN"
+          from: "GITHUB_ACCESS_TOKEN"
+      image: "sd2879/coral-repounderstanding:latest"
+
+  deepresearch:
     options:
       - name: "OPENAI_API_KEY"
         type: "string"
         description: "OpenAI API Key"
+      - name: "LINKUP_API_KEY"
+        type: "string"
+        description: "LinkUp API Key. Get from https://linkup.so/"
 
     runtime:
-      type: "executable"
-      command: [ "bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/mcp_example_camel_math.py" ]
+      type: "docker"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"
+      image: "sd2879/coral-opendeepresearch:latest"
+
   interface:
     options:
       - name: "OPENAI_API_KEY"
         type: "string"
         description: "OpenAI API Key"
+      - name: "HUMAN_RESPONSE"
+        type: "string"
+        description: "Human response to be used in the interface agent"
 
     runtime:
-      type: "executable"
-      command: [ "bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/mcp_example_camel_interface.py" ]
+      type: "docker"
+      image: "sd2879/coral-interface-agent:latest"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"
+        - name: "HUMAN_RESPONSE"
+          from: "HUMAN_RESPONSE"
 
 # Uncomment to configure an external application source
 # applicationSource:

--- a/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/Orchestrator.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/Orchestrator.kt
@@ -1,11 +1,17 @@
 package org.coralprotocol.coralserver.orchestrator
 
+import com.chrynan.uri.core.Uri
 import kotlinx.coroutines.*
 import org.coralprotocol.coralserver.session.GraphAgent
 import org.coralprotocol.coralserver.orchestrator.runtime.AgentRuntime
 
 interface Orchestrate {
-    fun spawn(agentName: String, connectionUrl: String, options: Map<String, ConfigValue>): OrchestratorHandle
+    fun spawn(
+        agentName: String,
+        port: UShort, // implementations might misleadingly ignore this port, TODO: Make it less misleading
+        relativeMcpServerUri: Uri,
+        options: Map<String, ConfigValue>
+    ): OrchestratorHandle
 }
 
 interface OrchestratorHandle {
@@ -17,26 +23,52 @@ class Orchestrator(
 ) {
     private val handles: MutableList<OrchestratorHandle> = mutableListOf()
 
-    fun spawn(type: AgentType, agentName: String, connectionUrl: String, options: Map<String, ConfigValue>) {
-        spawn(registry.get(type), agentName = agentName, connectionUrl = connectionUrl, options = options)
+    fun spawn(type: AgentType, agentName: String, port: UShort, relativeMcpServerUri: Uri, options: Map<String, ConfigValue>) {
+        spawn(registry.get(type), agentName = agentName, port = port, relativeMcpServerUri = relativeMcpServerUri, options = options)
     }
 
-    fun spawn(agent: RegistryAgent, agentName: String, connectionUrl: String, options: Map<String, ConfigValue>) {
-        handles.add(agent.runtime.spawn(agentName = agentName, connectionUrl = connectionUrl, options = options))
+    fun spawn(agent: RegistryAgent, agentName: String, port: UShort, relativeMcpServerUri: Uri, options: Map<String, ConfigValue>) {
+        handles.add(
+            agent.runtime.spawn(
+                agentName = agentName,
+                port = port,
+                relativeMcpServerUri = relativeMcpServerUri,
+                options = options
+            )
+        )
     }
 
-    fun spawn(runtime: AgentRuntime, agentName: String, connectionUrl: String, options: Map<String, ConfigValue>) {
-        handles.add(runtime.spawn(agentName = agentName, connectionUrl = connectionUrl, options = options))
+    fun spawn(runtime: AgentRuntime, agentName: String, port: UShort, relativeMcpServerUri: Uri, options: Map<String, ConfigValue>) {
+        handles.add(
+            runtime.spawn(
+                agentName = agentName,
+                port = port,
+                relativeMcpServerUri = relativeMcpServerUri,
+                options = options
+            )
+        )
     }
 
-    fun spawn(type: GraphAgent, agentName: String, connectionUrl: String) {
+    fun spawn(type: GraphAgent, agentName: String, port: UShort, relativeMcpServerUri: Uri) {
         when (type) {
             is GraphAgent.Local -> {
-                spawn(type.agentType, agentName = agentName, connectionUrl = connectionUrl, options = type.options)
+                spawn(
+                    type.agentType,
+                    agentName = agentName,
+                    port = port,
+                    relativeMcpServerUri = relativeMcpServerUri,
+                    options = type.options
+                )
             }
 
             is GraphAgent.Remote -> {
-                spawn(type.remote, agentName = agentName, connectionUrl = connectionUrl, options = type.options)
+                spawn(
+                    type.remote,
+                    agentName = agentName,
+                    port = port,
+                    relativeMcpServerUri = relativeMcpServerUri,
+                    options = type.options
+                )
             }
         }
     }

--- a/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/AgentRuntime.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/AgentRuntime.kt
@@ -21,13 +21,4 @@ sealed class AgentRuntime : Orchestrate {
             TODO("request agent from remote server")
         }
     }
-
-    @Serializable
-    @SerialName("docker")
-    data class Docker(val container: String) : AgentRuntime() {
-        override fun spawn(agentName: String, connectionUrl: String, options: Map<String, ConfigValue>): OrchestratorHandle {
-            TODO("Not yet implemented")
-        }
-    }
-
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/AgentRuntime.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/AgentRuntime.kt
@@ -1,5 +1,6 @@
 package org.coralprotocol.coralserver.orchestrator.runtime
 
+import com.chrynan.uri.core.Uri
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import org.coralprotocol.coralserver.orchestrator.ConfigValue
@@ -17,7 +18,12 @@ sealed class AgentRuntime : Orchestrate {
         val appId: String,
         val privacyKey: String,
     ) : AgentRuntime() {
-        override fun spawn(agentName: String, connectionUrl: String, options: Map<String, ConfigValue>): OrchestratorHandle {
+        override fun spawn(
+            agentName: String,
+            port: UShort,
+            relativeMcpServerUri: Uri,
+            options: Map<String, ConfigValue>
+        ): OrchestratorHandle {
             TODO("request agent from remote server")
         }
     }

--- a/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/Docker.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/Docker.kt
@@ -23,7 +23,7 @@ private val logger = KotlinLogging.logger {}
 @Serializable
 @SerialName("docker")
 data class Docker(
-    val container: String,
+    val image: String,
     val environment: List<EnvVar> = listOf()
 ) : AgentRuntime() {
     private val dockerClientConfig: DockerClientConfig = DefaultDockerClientConfig.createDefaultConfigBuilder()

--- a/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/Docker.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/Docker.kt
@@ -1,0 +1,73 @@
+package org.coralprotocol.coralserver.orchestrator.runtime
+
+import com.github.dockerjava.api.exception.NotModifiedException
+import com.github.dockerjava.core.DefaultDockerClientConfig
+import com.github.dockerjava.core.DockerClientBuilder
+import com.github.dockerjava.core.DockerClientConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import org.coralprotocol.coralserver.orchestrator.ConfigValue
+import org.coralprotocol.coralserver.orchestrator.OrchestratorHandle
+import kotlin.time.Duration.Companion.seconds
+
+private val logger = KotlinLogging.logger {}
+
+@Serializable
+@SerialName("docker")
+data class Docker(val container: String) : AgentRuntime() {
+    private val dockerClientConfig: DockerClientConfig = DefaultDockerClientConfig.createDefaultConfigBuilder()
+        .withDockerHost("unix:///var/run/docker.sock") // TODO: make this configurable
+        .build()
+    private val dockerClient = DockerClientBuilder.getInstance(dockerClientConfig).build()
+
+    override fun spawn(
+        agentName: String,
+        connectionUrl: String,
+        options: Map<String, ConfigValue>
+    ): OrchestratorHandle {
+        logger.info { "Spawning Docker container: $container" }
+
+        val containerCreation = dockerClient.createContainerCmd(container)
+            .withName(agentName)
+            .withEnv(options.map { "${it.key}=${it.value}" })
+            .exec()
+
+        dockerClient.startContainerCmd(containerCreation.id).exec()
+
+        return object : OrchestratorHandle {
+            override suspend fun destroy() {
+                withContext(processContext) {
+                    warnOnNotModifiedExceptions { dockerClient.stopContainerCmd(containerCreation.id).exec() }
+                    warnOnNotModifiedExceptions {
+                        withTimeoutOrNull(30.seconds) {
+                            dockerClient.removeContainerCmd(containerCreation.id)
+                                .withRemoveVolumes(true)
+                                .exec()
+                            return@withTimeoutOrNull true
+                        } ?: let {
+                            logger.warn { "Docker container $agentName did not stop in time, force removing it" }
+                            dockerClient.removeContainerCmd(containerCreation.id)
+                                .withRemoveVolumes(true)
+                                .withForce(true)
+                                .exec()
+                        }
+                        logger.info { "Docker container $agentName stopped and removed" }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private suspend fun warnOnNotModifiedExceptions(block: suspend () -> Unit): Unit {
+    try {
+        block()
+    } catch (e: NotModifiedException) {
+        logger.warn { "Docker operation was not modified: ${e.message}" }
+    } catch (e: Exception) {
+        throw e
+    }
+}

--- a/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/Docker.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/orchestrator/runtime/Docker.kt
@@ -37,7 +37,7 @@ data class Docker(
         relativeMcpServerUri: Uri,
         options: Map<String, ConfigValue>
     ): OrchestratorHandle {
-        logger.info { "Spawning Docker container: $container" }
+        logger.info { "Spawning Docker container with image: $image" }
         val fullConnectionUrl =
             "http://host.docker.internal:$port/${relativeMcpServerUri.path}${relativeMcpServerUri.query?.let { "?$it" } ?: ""}"
 
@@ -47,7 +47,7 @@ data class Docker(
         }
         val allEnvs = resolvedEnvs + "CORAL_CONNECTION_URL=$fullConnectionUrl"
 
-        val containerCreation = dockerClient.createContainerCmd(container)
+        val containerCreation = dockerClient.createContainerCmd(image)
             .withName(getDockerContainerName(relativeMcpServerUri, agentName))
             .withEnv(allEnvs)
             .withAttachStdout(true)

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionManager.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionManager.kt
@@ -1,5 +1,7 @@
 package org.coralprotocol.coralserver.session
 
+import com.chrynan.uri.core.Uri
+import com.chrynan.uri.core.fromParts
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
@@ -100,9 +102,10 @@ class SessionManager(val orchestrator: Orchestrator = Orchestrator(), val port: 
 
             it.agents.forEach { agent ->
                 orchestrator.spawn(
-                    agent.value,
+                    type = agent.value,
+                    port = port,
                     agentName = agent.key.toString(),
-                    connectionUrl = "http://localhost:${port}/${applicationId}/${privacyKey}/${sessionId}/sse?agentId=${agent.key}"
+                    relativeMcpServerUri = Uri.fromParts(scheme = "http", path = "${applicationId}/${privacyKey}/${sessionId}/sse", query = "agentId=${agent.key}")
                 )
             }
             subgraphs

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionModels.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionModels.kt
@@ -12,7 +12,7 @@ import org.coralprotocol.coralserver.orchestrator.runtime.AgentRuntime
 @Serializable
 data class CreateSessionRequest(
     val applicationId: String,
-    val sessionId: String?,
+    val sessionId: String? = null,
     val privacyKey: String,
     val agentGraph: AgentGraphRequest?,
 )

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ registry:
           from: "OPENAI_API_KEY"
         - name: "GITHUB_ACCESS_TOKEN"
           from: "GITHUB_ACCESS_TOKEN"
-      container: "sd2879/coral-repounderstanding:latest"
+      image: "sd2879/coral-repounderstanding:latest"
 
   deepresearch:
     options:
@@ -57,7 +57,7 @@ registry:
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"
-      container: "sd2879/coral-opendeepresearch:latest"
+      image: "sd2879/coral-opendeepresearch:latest"
 
   interface:
     options:
@@ -70,7 +70,7 @@ registry:
 
     runtime:
       type: "docker"
-      container: "sd2879/coral-interface-agent:latest"
+      image: "sd2879/coral-interface-agent:latest"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,63 +13,69 @@ applications:
 
 # Registry of agents we can orchestrate
 registry:
-  test:
-    options:
-      - name: "NAME"
-        type: "string"
-        description: "Test agent name"
-    runtime:
-      type: "executable"
-      command: ["bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/test.py"]
-      environment:
-        - option: "NAME"
-  search:
+  #  test:
+  #    options:
+  #      - name: "NAME"
+  #        type: "string"
+  #        description: "Test agent name"
+  #    runtime:
+  #      type: "executable"
+  #      command: ["bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/test.py"]
+  #      environment:
+  #        - option: "NAME"
+  repounderstanding:
     # Exposed configuration for consumers of this agent
     options:
       - name: "OPENAI_API_KEY"
         type: "string"
         description: "OpenAI API Key"
-      - name: "GOOGLE_API_KEY"
+      - name: "GITHUB_ACCESS_TOKEN"
         type: "string"
-        description: "Google API Key"
-      - name: "SEARCH_ENGINE_ID"
-        type: "string"
-        description: "Google Search Engine ID"
+        description: "GitHub Access Token. Can be blank if you're ok with unauthed rate limits."
 
     # How this agent is actually orchestrated locally
     runtime:
-      type: "executable"
-      command: [ "bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/mcp_example_camel_search.py" ]
-
+      type: "docker"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"
-        - option: "GOOGLE_API_KEY"
-        - option: "SEARCH_ENGINE_ID"
-  math:
+        - name: "GITHUB_ACCESS_TOKEN"
+          from: "GITHUB_ACCESS_TOKEN"
+      container: "sd2879/coral-repounderstanding:latest"
+
+  deepresearch:
     options:
       - name: "OPENAI_API_KEY"
         type: "string"
         description: "OpenAI API Key"
+      - name: "LINKUP_API_KEY"
+        type: "string"
+        description: "LinkUp API Key. Get from https://linkup.so/"
 
     runtime:
-      type: "executable"
-      command: [ "bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/mcp_example_camel_math.py" ]
+      type: "docker"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"
+      container: "sd2879/coral-opendeepresearch:latest"
+
   interface:
     options:
       - name: "OPENAI_API_KEY"
         type: "string"
         description: "OpenAI API Key"
+      - name: "HUMAN_RESPONSE"
+        type: "string"
+        description: "Human response to be used in the interface agent"
 
     runtime:
       type: "docker"
-      container: "fe689c04421c"
+      container: "sd2879/coral-interface-agent:latest"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"
+        - name: "HUMAN_RESPONSE"
+          from: "HUMAN_RESPONSE"
 
 # Uncomment to configure an external application source
 # applicationSource:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,8 +65,8 @@ registry:
         description: "OpenAI API Key"
 
     runtime:
-      type: "executable"
-      command: [ "bash", "examples/camel-search-maths/venv.sh", "examples/camel-search-maths/mcp_example_camel_interface.py" ]
+      type: "docker"
+      container: "fe689c04421c"
       environment:
         - name: "API_KEY"
           from: "OPENAI_API_KEY"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,7 +31,7 @@ registry:
         description: "OpenAI API Key"
       - name: "GITHUB_ACCESS_TOKEN"
         type: "string"
-        description: "GitHub Access Token. Can be blank if you're ok with unauthed rate limits."
+        description: "GitHub Access Token"
 
     # How this agent is actually orchestrated locally
     runtime:


### PR DESCRIPTION
Allows specifying agent types with docker runtimes, which when created connect to the orchestrating mcp server running on the container's host.

Creating sessions whose underlying registration is through the docker runtime is exactly the same, though I make some example changes.

Before undrafting, I will organise the examples a bit better and preserve the executable runtime examples.