### PR TITLE
Use relative paths in registry.toml, coral-agent.toml and executable runtimes

### DIFF
--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/RegistryAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/RegistryAgent.kt
@@ -11,6 +11,7 @@ import org.coralprotocol.coralserver.agent.runtime.RuntimeId
 import org.coralprotocol.coralserver.config.SecurityConfig
 import org.coralprotocol.coralserver.routes.api.v1.filterNotNullValues
 import java.io.File
+import java.nio.file.Path
 
 private val logger = KotlinLogging.logger {  }
 
@@ -18,6 +19,7 @@ class RegistryAgent(
     val info: RegistryAgentInfo,
     val runtimes: LocalAgentRuntimes,
     val options: Map<String, AgentOption>,
+    val path: Path,
     unresolvedExportSettings: UnresolvedAgentExportSettingsMap
 ) {
     val exportSettings: AgentExportSettingsMap = unresolvedExportSettings.mapValues { (runtime, settings) ->
@@ -75,5 +77,8 @@ fun resolveRegistryAgentFromStream(
         unresolved.unresolvedExportSettings += exportSettings
     }
 
-    return unresolved.resolve(context).first()
+    return unresolved.resolve(AgentResolutionContext(
+        registryResolutionContext = context,
+        path = file.toPath().parent
+    )).first()
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/RegistryResolutionContext.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/RegistryResolutionContext.kt
@@ -1,9 +1,0 @@
-package org.coralprotocol.coralserver.agent.registry
-
-import net.peanuuutz.tomlkt.Toml
-import org.coralprotocol.coralserver.config.Config
-
-data class RegistryResolutionContext(
-    val serializer: Toml,
-    val config: Config
-)

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/ResolutionContext.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/ResolutionContext.kt
@@ -1,0 +1,34 @@
+package org.coralprotocol.coralserver.agent.registry
+
+import net.peanuuutz.tomlkt.Toml
+import org.coralprotocol.coralserver.config.Config
+import java.nio.file.Path
+import kotlin.io.path.exists
+
+abstract class ResolutionContext() {
+    abstract val path: Path
+
+    /**
+     * Tries to resolve a local path.  If the path does not exist, the original path will be returned.
+     */
+    fun tryRelative(other: Path): Path {
+        val relative = path.resolve(other)
+        return if (relative.exists()) {
+            relative
+        }
+        else {
+            other
+        }
+    }
+}
+
+data class RegistryResolutionContext(
+    val serializer: Toml,
+    val config: Config,
+    override val path: Path
+) : ResolutionContext()
+
+data class AgentResolutionContext(
+    val registryResolutionContext: RegistryResolutionContext,
+    override val path: Path
+) : ResolutionContext()

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/UnresolvedInlineRegistryAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/UnresolvedInlineRegistryAgent.kt
@@ -16,12 +16,13 @@ data class UnresolvedInlineRegistryAgent(
     @Description("The options that this agent supports, for example the API keys required for the agent to function")
     val options: Map<String, AgentOption>,
 ) : UnresolvedRegistryAgent() {
-    override fun resolve(context: RegistryResolutionContext): List<RegistryAgent> {
+    override fun resolve(context: AgentResolutionContext): List<RegistryAgent> {
         return listOf(RegistryAgent(
             info = agentInfo,
             runtimes = runtimes,
             options = options,
-            unresolvedExportSettings = unresolvedExportSettings
+            unresolvedExportSettings = unresolvedExportSettings,
+            path = context.path
         ))
     }
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/UnresolvedRegistryAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/UnresolvedRegistryAgent.kt
@@ -13,5 +13,5 @@ abstract class UnresolvedRegistryAgent(
     @SerialName("export")
     var unresolvedExportSettings: UnresolvedAgentExportSettingsMap = mapOf()
 ) {
-    abstract fun resolve(context: RegistryResolutionContext): List<RegistryAgent>
+    abstract fun resolve(context: AgentResolutionContext): List<RegistryAgent>
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/reference/GitUnresolvedRegistryAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/reference/GitUnresolvedRegistryAgent.kt
@@ -27,7 +27,7 @@ data class GitUnresolvedRegistryAgent (
     @Transient
     private val encoder = Base64.getUrlEncoder()
 
-    override fun resolve(context: RegistryResolutionContext): List<RegistryAgent> {
+    override fun resolve(context: AgentResolutionContext): List<RegistryAgent> {
         val safeRepoName = encoder.encodeToString(repo.toByteArray())
         val identifiers = mapOf(
             "branch" to branch,
@@ -46,7 +46,7 @@ data class GitUnresolvedRegistryAgent (
             ?: throw RegistryException("git-agent (repo $repo) must specify one of branch, tag, or rev")
 
         val safeRepoPath = Path.of(safeRepoName, idType, encoder.encodeToString(idValue.toByteArray()))
-        val fullRepoPath = context.config.cache.agent.resolve(safeRepoPath)
+        val fullRepoPath = context.registryResolutionContext.config.cache.agent.resolve(safeRepoPath)
         val fullAgentTomlPath = fullRepoPath.resolve(AGENT_FILE)
 
         if (!fullAgentTomlPath.toFile().exists()) {
@@ -78,7 +78,7 @@ data class GitUnresolvedRegistryAgent (
         try {
             return listOf(resolveRegistryAgentFromStream(
                 file = fullAgentTomlPath.toFile(),
-                context = context,
+                context = context.registryResolutionContext,
                 exportSettings = unresolvedExportSettings
             ))
         }

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/reference/IndexUnresolvedRegistryAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/reference/IndexUnresolvedRegistryAgent.kt
@@ -2,6 +2,7 @@ package org.coralprotocol.coralserver.agent.registry.reference
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.coralprotocol.coralserver.agent.registry.AgentResolutionContext
 import org.coralprotocol.coralserver.agent.registry.RegistryAgent
 import org.coralprotocol.coralserver.agent.registry.RegistryResolutionContext
 import org.coralprotocol.coralserver.agent.registry.UnresolvedRegistryAgent
@@ -17,13 +18,14 @@ data class IndexUnresolvedRegistryAgent(
     val indexer: String? = null
 ) : UnresolvedRegistryAgent() {
 
-    override fun resolve(context: RegistryResolutionContext): List<RegistryAgent> {
+    override fun resolve(context: AgentResolutionContext): List<RegistryAgent> {
         return versions.map {
             context
+                .registryResolutionContext
                 .config
                 .registryConfig
                 .getIndexer(indexer)
-                .resolveAgent(context, mapOf(), name, it)
+                .resolveAgent(context.registryResolutionContext, mapOf(), name, it)
         }
     }
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/reference/LocalUnresolvedRegistryAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/registry/reference/LocalUnresolvedRegistryAgent.kt
@@ -16,12 +16,12 @@ private val logger = KotlinLogging.logger {}
 data class LocalUnresolvedRegistryAgent(
     val path: String
 ) : UnresolvedRegistryAgent() {
-    override fun resolve(context: RegistryResolutionContext): List<RegistryAgent> {
-        val agentTomlFile = Path.of(path, AGENT_FILE)
+    override fun resolve(context: AgentResolutionContext): List<RegistryAgent> {
+        val agentTomlFile = context.tryRelative(Path.of(AGENT_FILE))
         try {
             return listOf(resolveRegistryAgentFromStream(
                 file = agentTomlFile.toFile(),
-                context = context,
+                context = context.registryResolutionContext,
                 exportSettings = unresolvedExportSettings
             ))
         }

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/runtime/ExecutableRuntime.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/runtime/ExecutableRuntime.kt
@@ -30,6 +30,7 @@ data class ExecutableRuntime(
         val agentLogger = KotlinLogging.logger("ExecutableRuntime:${params.agentName}")
 
         val processBuilder = ProcessBuilder()
+        processBuilder.directory(params.path.toFile())
         val processEnvironment = processBuilder.environment()
 
         val apiUrl = applicationRuntimeContext.getApiUrl(AddressConsumer.LOCAL)

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/runtime/Orchestrator.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/runtime/Orchestrator.kt
@@ -107,6 +107,7 @@ class Orchestrator(
             privacyKey = privacyKey,
             systemPrompt = graphAgent.systemPrompt,
             options = graphAgent.options,
+            path = graphAgent.registryAgent.path
         )
 
         val handles = handles.getOrPut(session.id) { mutableListOf() }
@@ -173,6 +174,7 @@ class Orchestrator(
             agentName = agentName,
             systemPrompt = graphAgent.systemPrompt,
             options = graphAgent.options,
+            path = graphAgent.registryAgent.path
         )
 
         when (val provider = graphAgent.provider) {

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/runtime/RuntimeParams.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/runtime/RuntimeParams.kt
@@ -4,12 +4,14 @@ import org.coralprotocol.coralserver.agent.registry.AgentOptionValue
 import org.coralprotocol.coralserver.agent.registry.AgentRegistryIdentifier
 import org.coralprotocol.coralserver.session.LocalSession
 import org.coralprotocol.coralserver.session.remote.RemoteSession
+import java.nio.file.Path
 
 sealed interface RuntimeParams {
     val agentId: AgentRegistryIdentifier
     val agentName: String
     val systemPrompt: String?
     val options: Map<String, AgentOptionValue>
+    val path: Path
 
     data class Local(
         val session: LocalSession,
@@ -19,6 +21,7 @@ sealed interface RuntimeParams {
         override val agentName: String,
         override val systemPrompt: String?,
         override val options: Map<String, AgentOptionValue>,
+        override val path: Path,
     ): RuntimeParams
 
     data class Remote(
@@ -27,5 +30,6 @@ sealed interface RuntimeParams {
         override val agentName: String,
         override val systemPrompt: String?,
         override val options: Map<String, AgentOptionValue>,
+        override val path: Path,
     ): RuntimeParams
 }


### PR DESCRIPTION
- agents referenced by local file will now additionally search relativ to the registry's path
- agents now have access to the registry path and the coral-agent.toml path
- runtimes now have access to the coral-agent.toml path 
- the executable runtime now uses the path of the coral-agent.toml to set the working directory for spawning processes