### PR TITLE
Add agent sleeping

### DIFF
--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgent.kt
@@ -87,6 +87,18 @@ data class GraphAgent(
     val x402Budgets: List<X402BudgetedResource>,
 
     /**
+     * A set of events that should cause this agent to enter a sleeping state
+     * @see GraphAgentRequest.sleepEvents
+     */
+    val sleepEvents: Set<SleepEvent> = emptySet(),
+
+    /**
+     * A set of events that should cause this agent to wake from a sleeping state
+     * @see GraphAgentRequest.sleepEvents
+     */
+    val wakeEvents: Set<WakeEvent> = emptySet(),
+
+    /**
      * Runtime secret ID.  This is given to agents as an environment variable so that they may identify themselves to
      * the server securely.  This is useful for example, when consuming x402 budgets, we do not want to let agent A
      * access a x402 budget given to agent B.

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgentRequest.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgentRequest.kt
@@ -48,6 +48,14 @@ data class GraphAgentRequest(
 
     @Description("An optional list of resources and an accompanied budget that this agent may spend on services that accept x402 payments")
     val x402Budgets: List<X402BudgetedResource> = listOf(),
+
+    @Description("Events that should cause this agent to go to sleep")
+    @SerialName("sleepEvents")
+    val sleepEvents: Set<SleepEvent> = emptySet(),
+
+    @Description("Events that should cause this agent to wake up")
+    @SerialName("wakeEvents")
+    val wakeEvents: Set<WakeEvent> = emptySet(),
 ) {
     /**
      * Given a reference to the agent registry [AgentRegistry], this function will attempt to convert this request into
@@ -124,6 +132,38 @@ data class GraphAgentRequest(
             plugins = plugins,
             provider = provider,
             x402Budgets = x402Budgets,
+            sleepEvents = sleepEvents,
+            wakeEvents = wakeEvents,
         )
     }
+}
+
+/**
+ * Events that will put the agent into a sleeping state.
+ */
+@Serializable
+enum class SleepEvent {
+    @SerialName("agent_started")
+    AGENT_STARTED,
+
+    @SerialName("removed_from_last_thread")
+    REMOVED_FROM_LAST_THREAD,
+
+    @SerialName("last_thread_closed")
+    LAST_THREAD_CLOSED,
+}
+
+/**
+ * Events that will wake the agent from a sleeping state.
+ */
+@Serializable
+enum class WakeEvent {
+    @SerialName("added_to_any_thread")
+    ADDED_TO_ANY_THREAD,
+
+    @SerialName("added_to_thread_first_time")
+    ADDED_TO_THREAD_FIRST_TIME,
+
+    @SerialName("mentioned")
+    MENTIONED,
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/mcp/McpTool.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/mcp/McpTool.kt
@@ -23,6 +23,7 @@ abstract class McpTool<T>() {
     internal abstract suspend fun execute(mcpServer: CoralAgentIndividualMcp, arguments: T): McpToolResult
 
     internal suspend fun executeRaw(mcpServer: CoralAgentIndividualMcp, request: CallToolRequest): CallToolResult {
+        mcpServer.localSession.awaitAwake(mcpServer.connectedAgentId)
 
         val arguments = try {
             apiJsonConfig.decodeFromString(argumentsSerializer, request.arguments.toString())

--- a/src/main/kotlin/org/coralprotocol/coralserver/mcp/resources/AgentResource.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/mcp/resources/AgentResource.kt
@@ -6,7 +6,8 @@ import io.modelcontextprotocol.kotlin.sdk.TextResourceContents
 import org.coralprotocol.coralserver.mcp.McpResources.AGENT_RESOURCE_URI
 import org.coralprotocol.coralserver.server.CoralAgentIndividualMcp
 
-private fun CoralAgentIndividualMcp.handler(request: ReadResourceRequest): ReadResourceResult {
+private suspend fun CoralAgentIndividualMcp.handler(request: ReadResourceRequest): ReadResourceResult {
+    localSession.awaitAwake(connectedAgentId)
     val otherAgents = localSession
         .agents
         .filter { (name, _) -> name != connectedAgentId }

--- a/src/main/kotlin/org/coralprotocol/coralserver/mcp/resources/InstructionResource.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/mcp/resources/InstructionResource.kt
@@ -21,7 +21,8 @@ and expect or require a response from another agent, use the $WAIT_FOR_MENTIONS 
 In most cases assistant message output will not reach the user.  Use tooling where possible to communicate with the user instead.
 """
 
-private fun handle(request: ReadResourceRequest): ReadResourceResult {
+private suspend fun CoralAgentIndividualMcp.handle(request: ReadResourceRequest): ReadResourceResult {
+    localSession.awaitAwake(connectedAgentId)
     return ReadResourceResult(
         contents = listOf(
             TextResourceContents(
@@ -39,7 +40,7 @@ fun CoralAgentIndividualMcp.addInstructionResource() {
         description = "Coral instructions resource",
         uri = INSTRUCTION_RESOURCE_URI.toString(),
         mimeType = "text/markdown",
-        readHandler = ::handle,
+        readHandler = { request -> this.handle(request) },
     )
     // deprecated
     addResource(
@@ -47,6 +48,6 @@ fun CoralAgentIndividualMcp.addInstructionResource() {
         description = "Coral instructions resource",
         uri = "Instruction.resource",
         mimeType = "text/markdown",
-        readHandler = ::handle,
+        readHandler = { request -> this.handle(request) },
     )
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/mcp/resources/MessageResource.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/mcp/resources/MessageResource.kt
@@ -10,7 +10,8 @@ import org.coralprotocol.coralserver.models.ResolvedThread
 import org.coralprotocol.coralserver.models.resolve
 import org.coralprotocol.coralserver.server.CoralAgentIndividualMcp
 
-private fun CoralAgentIndividualMcp.handler(request: ReadResourceRequest): ReadResourceResult {
+private suspend fun CoralAgentIndividualMcp.handler(request: ReadResourceRequest): ReadResourceResult {
+    localSession.awaitAwake(connectedAgentId)
     val threadsAgentPrivyIn: List<ResolvedThread> = this.localSession.getAllThreadsAgentParticipatesIn(this.connectedAgentId).map { it -> it.resolve() }
     val renderedThreads: String = XML.encodeToString(threadsAgentPrivyIn, rootName = QName("threads"))
     return ReadResourceResult(

--- a/src/main/kotlin/org/coralprotocol/coralserver/routes/api/v1/SleepingRoutes.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/routes/api/v1/SleepingRoutes.kt
@@ -1,0 +1,110 @@
+package org.coralprotocol.coralserver.routes.api.v1
+
+import io.github.smiley4.ktoropenapi.resources.get
+import io.github.smiley4.ktoropenapi.resources.post
+import io.github.smiley4.ktoropenapi.resources.put
+import io.ktor.http.*
+import io.ktor.resources.*
+import io.ktor.server.request.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import kotlinx.serialization.Serializable
+import org.coralprotocol.coralserver.server.RouteException
+import org.coralprotocol.coralserver.session.LocalSessionManager
+
+@Resource("/api/v1/sessions/{sessionId}/{agentId}/sleeping")
+class Sleeping(val sessionId: String, val agentId: String)
+
+@Serializable
+data class SleepState(val sleeping: Boolean)
+
+
+fun Routing.sleepingRoutes(localSessionManager: LocalSessionManager) {
+
+    get<Sleeping>({
+        summary = "Get agent sleeping state"
+        description = "Returns whether a given agent instance in a session is sleeping"
+        operationId = "getAgentSleeping"
+        request {
+            pathParameter<String>("sessionId") { description = "The session ID" }
+            pathParameter<String>("agentId") { description = "The agent ID within the session" }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Success"
+                body<SleepState> { description = "Current sleeping state" }
+            }
+            HttpStatusCode.NotFound to {
+                description = "Session or agent not found"
+                body<RouteException> { description = "Error details" }
+            }
+        }
+    }) {
+        val session = localSessionManager.getSession(it.sessionId) ?: throw RouteException(HttpStatusCode.NotFound, "Session not found")
+        val agent = session.getAgent(it.agentId) ?: throw RouteException(HttpStatusCode.NotFound, "Agent not found in session")
+        call.respond(HttpStatusCode.OK, SleepState(agent.sleeping))
+    }
+
+    put<Sleeping>({
+        summary = "Set agent sleeping state"
+        description = "Sets whether a given agent instance in a session is sleeping"
+        operationId = "setAgentSleeping"
+        request {
+            body<SleepState> { description = "Desired sleeping state" }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Success"
+                body<SleepState> { description = "Updated sleeping state" }
+            }
+            HttpStatusCode.NotFound to {
+                description = "Session or agent not found"
+                body<RouteException> { description = "Error details" }
+            }
+        }
+    }) { sleeping ->
+        val body = call.receive<SleepState>()
+        val result = setSleepingState(localSessionManager, sleeping.sessionId, sleeping.agentId, body.sleeping)
+        call.respond(HttpStatusCode.OK, result)
+    }
+    
+
+    // TODO: This POST endpoint duplicates the PUT behavior. Not strictly REST-compliant,
+    //       but provided because custom tools can only issue POST requests.
+    post<Sleeping>({
+        summary = "Set agent sleeping state (POST)"
+        description = "Same behavior as PUT: sets whether a given agent instance in a session is sleeping"
+        operationId = "setAgentSleepingPost"
+        request {
+            body<SleepState> { description = "Desired sleeping state" }
+        }
+        response {
+            HttpStatusCode.OK to {
+                description = "Success"
+                body<SleepState> { description = "Updated sleeping state" }
+            }
+            HttpStatusCode.NotFound to {
+                description = "Session or agent not found"
+                body<RouteException> { description = "Error details" }
+            }
+        }
+    }) { sleeping ->
+        val body = call.receive<SleepState>()
+        val result = setSleepingState(localSessionManager, sleeping.sessionId, sleeping.agentId, body.sleeping)
+        call.respond(HttpStatusCode.OK, result)
+    }
+}
+
+private fun setSleepingState(
+    localSessionManager: LocalSessionManager,
+    sessionId: String,
+    agentId: String,
+    desiredSleeping: Boolean
+): SleepState {
+    val session = localSessionManager.getSession(sessionId)
+        ?: throw RouteException(HttpStatusCode.NotFound, "Session not found")
+    if (!session.setAgentSleeping(agentId, desiredSleeping)) {
+        throw RouteException(HttpStatusCode.NotFound, "Agent not found in session")
+    }
+    return SleepState(session.isAgentSleeping(agentId))
+}

--- a/src/main/kotlin/org/coralprotocol/coralserver/server/CoralServer.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/server/CoralServer.kt
@@ -200,6 +200,7 @@ class CoralServer(
                 debugApiRoutes(localSessionManager)
                 sessionApiRoutes(registry, localSessionManager, devmode)
                 messageApiRoutes(mcpServersByTransportId, localSessionManager, remoteSessionManager)
+                sleepingRoutes(localSessionManager)
                 telemetryApiRoutes(localSessionManager)
                 documentationApiRoutes()
                 agentApiRoutes(registry, blockchainService, remoteSessionManager, jupiterService, config.paymentConfig)

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/models/SessionAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/models/SessionAgent.kt
@@ -13,6 +13,7 @@ data class SessionAgent(
     val id: String,
     var description: String = "",
     var state: SessionAgentState = SessionAgentState.Disconnected,
+    var sleeping: Boolean = false,
     var mcpUrl: String?,
     val extraTools: Set<CustomTool> = setOf(),
     val coralPlugins: Set<GraphAgentPlugin> = setOf(),


### PR DESCRIPTION
Context from message I sent in discussion in our community discord:

Since this relates to token savings, scaling and noise reduction, and the interface seems relatively stable it is a core functionality rather than a plugin.

With sleeping, agent instances will have a sleep state in the coral server, which is a changeable boolean.

A REST interface, looking something like GET, PUT, POST (for custom tools) /sessions/<session id>/<agent instance id>/sleeping will expose that sleeping state.

Agents in the graph will have added "sleep events" and "wake events" fields, which will be lists of events that cause the agent to be set to sleep or set to not sleep.

available wake events:
* added to any thread
* added to a thread the first time
* mentioned

available sleep events:
* removed from last thread
* last thread closed
* agent started

Agents start out not sleeping, unless they have the agent started sleep event.

When an agent's state is sleeping, any MCP call (including MCP resource GET, which should happen before every LLM request in supporting agents), or proxied LLM request will hang until the agent is awoken.

---

A common pattern would be to have all agents apart from 1 or a few starting agents in the graph set to sleep on agent started, and to awake when included in a thread, this would be well suited for search or chat applications,

Since there is a REST interface for sleeping agents, more advanced sleeping behaviour can be implemented by applications, and tools could be used to let agents to intentionally put themselves or others to sleep or awake.

In general this should help to make applications much more LLM token efficient