### PR TITLE
export dev .env option for GraphAgents

### DIFF
--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgent.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgent.kt
@@ -88,4 +88,9 @@ data class GraphAgent(
      * @see GraphAgentRequest.x402Budgets
      */
     val x402Budgets: List<X402BudgetedResource>,
+
+    /**
+     * @see GraphAgentRequest.exportDevEnvFile
+     */
+    val exportDevEnvFile: Boolean,
 )

--- a/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgentRequest.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/agent/graph/GraphAgentRequest.kt
@@ -50,6 +50,10 @@ data class GraphAgentRequest(
     @Description("An optional list of resources and an accompanied budget that this agent may spend on services that accept x402 payments")
     @Optional
     val x402Budgets: List<X402BudgetedResource> = listOf(),
+
+    @Description("Development option. If true, for agents loaded from a local `coral-agent.toml`, Coral will write a `coral-agent.dev.env` file and will NOT execute the agent runtime.")
+    @Optional
+    val exportDevEnvFile: Boolean = false,
 ) {
     /**
      * Given a reference to the agent registry [AgentRegistry], this function will attempt to convert this request into
@@ -131,6 +135,7 @@ data class GraphAgentRequest(
             plugins = plugins,
             provider = provider,
             x402Budgets = x402Budgets,
+            exportDevEnvFile = exportDevEnvFile,
         )
     }
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionAgentDisposableResource.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionAgentDisposableResource.kt
@@ -2,6 +2,7 @@ package org.coralprotocol.coralserver.session
 
 import org.apache.commons.io.file.PathUtils.deleteFile
 import org.coralprotocol.coralserver.config.DockerConfig
+import java.nio.file.Path
 import kotlin.io.path.createTempFile
 import kotlin.io.path.name
 import kotlin.io.path.writeBytes
@@ -18,6 +19,12 @@ sealed interface SessionAgentDisposableResource {
 
         override fun dispose() {
             deleteFile(file)
+        }
+    }
+
+    class DeleteFile(private val file: Path) : SessionAgentDisposableResource {
+        override fun dispose() {
+            runCatching { deleteFile(file) }
         }
     }
 }

--- a/src/main/kotlin/org/coralprotocol/coralserver/session/SessionAgentExecutionContext.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/session/SessionAgentExecutionContext.kt
@@ -2,7 +2,8 @@
 
 package org.coralprotocol.coralserver.session
 
-import io.ktor.utils.io.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.awaitCancellation
 import org.coralprotocol.coralserver.agent.graph.GraphAgentProvider
 import org.coralprotocol.coralserver.agent.registry.option.*
 import org.coralprotocol.coralserver.agent.runtime.ApplicationRuntimeContext
@@ -16,6 +17,10 @@ import org.coralprotocol.coralserver.util.utcTimeNow
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readLines
+import kotlin.io.path.writeText
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -23,6 +28,11 @@ class SessionAgentExecutionContext(
     val agent: SessionAgent,
     val applicationRuntimeContext: ApplicationRuntimeContext
 ) : KoinComponent {
+    private companion object {
+        private const val DEV_ENV_FILE_NAME = "coral-agent.dev.env"
+        private const val GITIGNORE_FILE_NAME = ".gitignore"
+    }
+
     val logger = agent.logger
     val name = agent.name
     val session = agent.session
@@ -131,6 +141,14 @@ class SessionAgentExecutionContext(
 
         try {
             handleRuntimeStarted()
+
+            // Export env vars to coral-agent.dev.env if appropriate and set, instead of launching the runtime for development purposes.
+            if (graphAgent.exportDevEnvFile && provider is GraphAgentProvider.Local && path != null) {
+                if (exportDevEnvFile(path)) {
+                    awaitCancellation() // Keep session alive as runtime wasn't launched
+                }
+            }
+
             if (provider is GraphAgentProvider.Local)
                 launchLocal(provider)
 
@@ -146,6 +164,60 @@ class SessionAgentExecutionContext(
 
         // todo: restart logic
         logger.info { "Agent ${agent.name} runtime exited" }
+    }
+
+    private fun exportDevEnvFile(agentDirectory: Path): Boolean {
+        val gitignore = agentDirectory.resolve(GITIGNORE_FILE_NAME)
+        val isAllowed = gitignore.exists() && gitignore.readLines().any {
+            Regex("""^\s*/?coral-agent\.dev\.env\s*$""").matches(it)
+        }
+
+        if (!isAllowed) {
+            logger.warn {
+                "Dev env export is enabled for agent ${agent.name}, but it did not create $DEV_ENV_FILE_NAME " +
+                    "because an adjacent $GITIGNORE_FILE_NAME did not contain a line matching $DEV_ENV_FILE_NAME"
+            }
+            return false
+        }
+
+        val envFile = agentDirectory.resolve(DEV_ENV_FILE_NAME)
+        logger.info { "Exporting $DEV_ENV_FILE_NAME for agent ${agent.name}" }
+        val env = buildEnvironment()
+            .toSortedMap()
+            .entries
+            .joinToString("\n", postfix = "\n") { (key, value) ->
+                "$key=${value.toDotEnvValue()}"
+            }
+
+        envFile.writeText(env)
+        disposableResources.add(SessionAgentDisposableResource.DeleteFile(envFile))
+
+        logger.info {
+            "Wrote dev env file for agent ${agent.name} to $envFile (will be deleted when the session ends)"
+        }
+        return true
+    }
+
+    private fun String.toDotEnvValue(): String {
+        if (isEmpty()) return "\"\""
+
+        val needsQuotes = any { it.isWhitespace() } || any { it == '#' || it == '"' || it == '\\' } || contains('\n') || contains('\r')
+        if (!needsQuotes) return this
+
+        val escaped = buildString {
+            for (c in this@toDotEnvValue) {
+                when (c) {
+                    '\\' -> append("\\\\")
+                    '"' -> append("\\\"")
+                    '\n' -> append("\\n")
+                    '\r' -> append("\\r")
+                    '\t' -> append("\\t")
+                    else -> append(c)
+                }
+            }
+        }
+
+        return "\"$escaped\""
     }
 
 

--- a/src/test/kotlin/org/coralprotocol/coralserver/utils/dsl/CommonGraphAgentBuilder.kt
+++ b/src/test/kotlin/org/coralprotocol/coralserver/utils/dsl/CommonGraphAgentBuilder.kt
@@ -20,6 +20,7 @@ open class CommonGraphAgentBuilder(
     var systemPrompt: String? = null
     var blocking: Boolean = true
     var provider: GraphAgentProvider = GraphAgentProvider.Local(RuntimeId.FUNCTION)
+    var exportDevEnvFile: Boolean = false
 
     protected val plugins = mutableSetOf<GraphAgentPlugin>()
     protected val x402Budgets = mutableListOf<X402BudgetedResource>()
@@ -63,7 +64,8 @@ class GraphAgentBuilder(name: String) : CommonGraphAgentBuilder(name) {
             customTools = customTools.toMap(),
             plugins = plugins.toSet(),
             provider = provider,
-            x402Budgets = x402Budgets.toList()
+            x402Budgets = x402Budgets.toList(),
+            exportDevEnvFile = exportDevEnvFile,
         )
     }
 }
@@ -95,7 +97,8 @@ class GraphAgentRequestBuilder(
             customToolAccess = customToolAccess,
             plugins = plugins,
             provider = provider,
-            x402Budgets = x402Budgets
+            x402Budgets = x402Budgets,
+            exportDevEnvFile = exportDevEnvFile,
         )
     }
 }


### PR DESCRIPTION
Agents with exportDevEnvFile set to true in the session will not have their runtimes executed.

Instead, if they have a coral-agent.toml file, and that file is adjacent to a .gitignore with cora-agent.dev.env ignored, a coral-agent.dev.env file will be created adjacent to the coral-agent.toml file.

The purpose of this is for agents to load for direct execution during development.

Since the agentSecret that is part of the MCP connection url passed to the agent only works for as long as the session, the file gets deleted when the session ends. This is for convenience and to prevent anyone being surprised by however their agent framework handles a 401 on the MCP connection. 