### PR TITLE
fix: stop implicitly ignoring ~/.coral/agents/* when agents are explicitly defined without including ~/.coral/agents/*

### DIFF
--- a/src/main/kotlin/org/coralprotocol/coralserver/config/RegistryConfig.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/config/RegistryConfig.kt
@@ -6,14 +6,14 @@ import kotlin.time.Duration
 data class RegistryConfig(
     /**
      * A list of agents available on the file system to add as local agents to this server.  This supports basic pattern
-     * matching.
+     * matching. Unless explicitly disabled, agents from the ~/.coral/agents/.. directory will still be included.
      */
-    val localAgents: List<String> = listOf(
-        // Agents added with coralizer link are separated by agent version at the time of linking
-        "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/*/*",
-        // For agents manually added it's more natural that they aren't separated by version
-        "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/*",
-    ),
+    val localAgents: List<String> = listOf(),
+
+    /**
+     * Whether to include agents that are in the user's coral home directory (~/.coral/agents/..).
+     */
+    val includeCoralHomeAgents: Boolean = true,
 
     /**
      * If this is non-zero, [localAgents] will be rescanned every [localAgentRescanTimer].  This must be used for

--- a/src/main/kotlin/org/coralprotocol/coralserver/modules/AgentModule.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/modules/AgentModule.kt
@@ -28,10 +28,12 @@ val agentModule = module {
 
             val allAgentSources = (config.localAgents + if (config.includeCoralHomeAgents) {
                 listOf(
-                    // Agents added with coralizer link are separated by agent version at the time of linking
+                    // Support separation by agent version
                     "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/*/*",
                     // For agents manually added it's more natural that they aren't separated by version
                     "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/*",
+                    // Specific directory that the coralizer should put links in to clearly separate manually managed
+                    "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/locallinked/*/*",
                 )
             } else {
                 emptyList()

--- a/src/main/kotlin/org/coralprotocol/coralserver/modules/AgentModule.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/modules/AgentModule.kt
@@ -26,7 +26,7 @@ val agentModule = module {
                 }
             }
 
-            val allAgentSources = config.localAgents + if (config.includeCoralHomeAgents) {
+            val allAgentSources = (config.localAgents + if (config.includeCoralHomeAgents) {
                 listOf(
                     // Agents added with coralizer link are separated by agent version at the time of linking
                     "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/*/*",
@@ -35,7 +35,7 @@ val agentModule = module {
                 )
             } else {
                 emptyList()
-            }.distinct()
+            }).distinct()
 
             allAgentSources.forEach {
                 logger.trace { "watching for agents matching pattern: $it" }

--- a/src/main/kotlin/org/coralprotocol/coralserver/modules/AgentModule.kt
+++ b/src/main/kotlin/org/coralprotocol/coralserver/modules/AgentModule.kt
@@ -8,6 +8,7 @@ import org.coralprotocol.coralserver.mcp.McpToolManager
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import java.nio.file.Path
 
 val agentModule = module {
     singleOf(::EchoDebugAgent)
@@ -25,7 +26,18 @@ val agentModule = module {
                 }
             }
 
-            config.localAgents.forEach {
+            val allAgentSources = config.localAgents + if (config.includeCoralHomeAgents) {
+                listOf(
+                    // Agents added with coralizer link are separated by agent version at the time of linking
+                    "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/*/*",
+                    // For agents manually added it's more natural that they aren't separated by version
+                    "${Path.of(System.getProperty("user.home"), ".coral", "agents")}/*",
+                )
+            } else {
+                emptyList()
+            }.distinct()
+
+            allAgentSources.forEach {
                 logger.trace { "watching for agents matching pattern: $it" }
                 addFileBasedSource(it, config.watchLocalAgents, config.localAgentRescanTimer)
             }


### PR DESCRIPTION
kinda related to \#\81 and \#\82 of cc issues